### PR TITLE
Streamline CI testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.bundle
 _site

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 rvm:
-- 2.3.0
+  - 2.3.0
 sudo: false
+bundler_args: --binstubs .bundle/binstubs --path .bundle
 install:
   - bundle install
 script:
-  - set -e
-  - bundle exec jekyll build
-  - htmlproofer ./_site
+  - script/cibuild

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ group :jekyll_plugins do
   gem "jekyll-paginate"
   gem "jekyll-feed"
   gem "jekyll"
-  gem "html-proofer"
 end
 
-group :test do
+group :test, :development do
   gem 'rake'
+  gem "html-proofer"
   gem 'html-pipeline', '~> 1.11'
   gem 'github-markdown', '~> 0.6.8'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,4 +91,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.14.2
+   1.14.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+#!/usr/bin/env rake
+
+require 'html-proofer'
+
+task :default => [:test]
+desc 'Runs the tests!'
+task :test do
+  sh "bundle exec jekyll build"
+  HTMLProofer.check_directory("./_site").run
+end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,20 @@
+#!/bin/sh
+#/ Usage: bootstrap
+#/
+#/ Install bundle dependencies.
+#/
+#/ Examples:
+#/
+#/   bootstrap
+#/
+
+set -e
+cd $(dirname "$0")/..
+
+[ "$1" = "--help" -o "$1" = "-h" -o "$1" = "help" ] && {
+    grep '^#/' <"$0"| cut -c4-
+    exit 0
+}
+
+rm -rf .bundle/{binstubs,config}
+bundle install --binstubs .bundle/binstubs --path .bundle

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,41 @@
+#!/bin/sh
+#/ Usage: cibuild
+#/
+#/ Run CI.
+#/
+#/ Examples:
+#/
+#/   cibuild
+#/
+
+set -e
+
+# GC customizations
+export RUBY_GC_MALLOC_LIMIT=79000000
+export RUBY_GC_HEAP_INIT_SLOTS=800000
+export RUBY_HEAP_FREE_MIN=100000
+export RUBY_HEAP_SLOTS_INCREMENT=400000
+export RUBY_HEAP_SLOTS_GROWTH_FACTOR=1
+
+export PATH="/usr/share/rbenv/shims:$PATH"
+export RACK_ROOT=$(cd "$(dirname $0)"/.. && pwd)
+export RACK_ENV="test"
+export RAILS_ENV="test"
+export RBENV_VERSION="2.3.0"
+
+# clean out the ruby environment
+export RUBYLIB=
+export RUBYOPT=
+
+# write some debug info
+ruby -v
+echo "hostname: $(hostname)"
+echo "pwd: $(pwd)"
+git --version
+
+# bootstrap gem environment changes
+cd "$RACK_ROOT"
+echo 'Bootstrapping gems...'
+script/bootstrap
+
+bundle exec rake test

--- a/script/server
+++ b/script/server
@@ -1,0 +1,16 @@
+#!/bin/sh
+#/ Usage: server [options]
+#/
+#/ Start the development server.
+#/
+#/ Examples:
+#/
+#/   server
+#/   server --incremental
+#/
+
+set -e
+
+script/update
+
+bundle exec jekyll serve "$@"

--- a/script/update
+++ b/script/update
@@ -1,0 +1,16 @@
+#!/bin/sh
+#/ Usage: update
+#/
+#/ Update bundle dependencies.
+#/
+#/ Examples:
+#/
+#/   update
+#/
+
+set -e
+
+set -e
+export CC=gcc
+
+script/bootstrap


### PR DESCRIPTION
This PR introducees CI testing similatr to our other repositories by introducing the `script/` folder and [_scripts to rule them all_](https://github.com/github/scripts-to-rule-them-all) files.